### PR TITLE
feat(data_product): validate schema before running. Closes #14.

### DIFF
--- a/src/tidylake/core/data_product.py
+++ b/src/tidylake/core/data_product.py
@@ -206,6 +206,21 @@ class DataProduct:
                                      Please set output_data when using a compute engine."
                     )
 
+                # Schema validation first
+                schemas = self.get_schemas()
+                defined_schema_props = schemas.get("defined_schema", {}).get("properties", {})
+                catalog_schema_props = schemas.get("catalog_schema", {}).get("properties", {})
+
+                all_keys = defined_schema_props.keys() | catalog_schema_props.keys()
+                for col in all_keys:
+                    def_type = defined_schema_props.get(col, {}).get("type", "<missing>")
+                    cat_type = catalog_schema_props.get(col, {}).get("type", "<missing>")
+                    if def_type != cat_type:
+                        raise RuntimeError(
+                            "Catalog schema is not updated according to manifest schema. "
+                            "Please update catalog before running data products."
+                        )
+                # Write dataset after schema validation
                 self.compute_engine.write_dataset(
                     self.name,
                     self.output_data,

--- a/tests/unit/test_data_product.py
+++ b/tests/unit/test_data_product.py
@@ -162,6 +162,7 @@ def test_run_with_compute_engine_writes_dataset():
     """Test run with compute engine writes dataset."""
     data_product = DataProduct(name="test_data_product", schema={}, script="package.module")
     engine = Mock()
+    engine.get_schema_from_catalog.return_value = {"catalog": "schema"}
     data_product.set_compute_engine(engine)
     data_product.set_output_data("test_data")
 
@@ -174,10 +175,31 @@ def test_run_with_compute_engine_writes_dataset():
     engine.write_dataset.assert_called_once_with("test_data_product", "test_data")
 
 
+def test_run_with_compute_engine_writes_dataset_outdated_schema():
+    """Test run with compute engine tries to write a dataset,
+    but fails because schemas (manifest and catalog) differ."""
+    # define schemas with differences
+    manifest_schema = {"properties": {"id": {"type": "string"}}}
+    catalog_schema = {"properties": {"id": {"type": "integer"}}}
+    data_product = DataProduct(name="test_data_product", schema=manifest_schema, script="package.module")
+    engine = Mock()
+    engine.get_schema_from_catalog.return_value = catalog_schema
+    data_product.set_compute_engine(engine)
+    data_product.set_output_data("test_data")
+
+    with (
+        patch("tidylake.core.data_product.execution_mode", "script"),
+        patch("tidylake.core.data_product.importlib.import_module"),
+        pytest.raises(RuntimeError, match="Catalog schema is not updated according to manifest schema."),
+    ):
+        data_product.run()
+
+
 def test_run_with_compute_engine_missing_output():
     """Test run with compute engine but no output data raises error."""
     data_product = DataProduct(name="test_data_product", schema={}, script="package.module")
     engine = Mock()
+    engine.get_schema_from_catalog.return_value = {"catalog": "schema"}
     data_product.set_compute_engine(engine)
 
     with (


### PR DESCRIPTION
      When a data product is run with a compute engine, a validation of the schema is performed before writing the data.

      It compares the schema defined in the manifest against the one in the catalog. If they differ, it will raise a
      RuntimeError, to avoid data inconsistencies.